### PR TITLE
Setting modem to LoRa mode before configuring LoRa registers

### DIFF
--- a/dragino_lora_app/main.c
+++ b/dragino_lora_app/main.c
@@ -261,6 +261,7 @@ void SetupLoRa()
     }
 
     opmode(OPMODE_SLEEP);
+    opmodeLora();
 
     // set frequency
     uint64_t frf = ((uint64_t)freq << 19) / 32000000;
@@ -442,7 +443,6 @@ int main (int argc, char *argv[]) {
     SetupLoRa();
 
     if (!strcmp("sender", argv[1])) {
-        opmodeLora();
         // enter standby mode (required for FIFO loading))
         opmode(OPMODE_STANDBY);
 
@@ -463,7 +463,6 @@ int main (int argc, char *argv[]) {
     } else {
 
         // radio init
-        opmodeLora();
         opmode(OPMODE_STANDBY);
         opmode(OPMODE_RX);
         printf("Listening at SF%i on %.6lf Mhz.\n", sf,(double)freq/1000000);


### PR DESCRIPTION
**Problem**

In the `SetupLoRa()` function of dragino_lora_app, the device is still in FSK/OOK mode (which is the default after reset). This means you cannot configure the LoRa mode registers until you explicitly enter that mode.

As far as I could test it, this affects at least `REG_SYNC_WORD` and `REG_SYMB_TIMEOUT_LSB`.

If you try another program as counterpart, the sync word difference will lead to only very few messages getting through, and that's hard to debug as the sync word shown in the code isn't actually applied.

Note: I only verified this for dragino_lora_app, but I think that the other apps will have the same issue which can be fixed in the same way.

**Solution**

I suggest entering LoRa mode directly after the reset and then writing to the configuration registers, so that the intended values are actually used by the modem.

**How to verify?**

You can verify this by adding the following print statements to check the register's actual values just before entering the transmit / receive loop:

```c++
printf("SymbTimeoutLsb: 0x%02x\n", readReg(REG_SYMB_TIMEOUT_LSB));
printf("Syncword: 0x%02x\n", readReg(REG_SYNC_WORD));
```

If the modem was still in FSK/OOK mode during setup, the results will be:

```
SymbTimeoutLsb: 0x64 // Still register's default value
Syncword: 0x12       // Still register's default value
```

But with the proposed change, you'll get the values that you've set in `SetupLora()`:

```
SymbTimeoutLsb: 0x08
Syncword: 0x34
```